### PR TITLE
Fix: Various isses related to coverage reports and Notebook tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,30 @@ Validates Jupyter Notebooks with pytest and nbmake.
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name   | Required | Default | Description                                       |
-| --------------- | -------- | ------- | ------------------------------------------------- |
-| PYTHON_VERSION  | True     |         | Python version used to run tests                  |
-| PERMIT_FAIL     | False    | False   | Continue even when one or more tests fails        |
-| PATH_PREFIX     | False    |         | Directory location containing Python project code |
-| PARALLEL_TESTS  | False    | False   | Parallel pytest/nbmake processes                  |
-| NBMAKE_KERNEL   | False    | False   | Force nbmake to use a specific kernel             |
-| INSTALL_KERNEL  | False    | False   | Install custom kernel before running tests        |
+| Variable Name   | Required | Default  | Description                                        |
+| --------------- | -------- | -------- | -------------------------------------------------- |
+| PYTHON_VERSION  | True     |          | Python version used to run tests                   |
+| PERMIT_FAIL     | False    | False    | Continue even when one or more tests fails         |
+| PATH_PREFIX     | False    |          | Directory location containing Python project code  |
+| PARALLEL_TESTS  | False    | False    | Parallel pytest/nbmake processes                   |
+| NBMAKE_KERNEL   | False    | False    | Force nbmake to use a specific kernel              |
+| INSTALL_KERNEL  | False    | False    | Install custom kernel before running tests         |
+| PYTEST_FLAGS    | False    | --no-cov | Pytest flags; coverage reports disabled by default |
 
 <!-- markdownlint-enable MD013 -->
 
 ## Implementation Details
 
 Refer to the following Python tool documentation: [nbmake](https://github.com/treebeardtech/nbmake)
+
+## Coverage Reports
+
+Notebook tests and coverage reports may not play nicely together. Coverage
+reports are setup in the pyproject.toml file. Certain options may cause
+Notebook tests to fail. For this reason, coverage reports are not generated
+by default through explicit flags/options sent to the pytest command. You can
+override this behaviour (and enable coverage reports) by setting the relevant
+"pytest_flags" action/input to a null/empty string.
 
 ## Notes
 

--- a/action.yaml
+++ b/action.yaml
@@ -39,6 +39,11 @@ inputs:
     description: "Install custom kernel prior to testing"
     type: string
     required: false
+  PYTEST_FLAGS:
+    description: "Flags to send to the pytest command"
+    type: string
+    required: false
+    default: "--no-cov"
 
 runs:
   using: "composite"
@@ -82,10 +87,10 @@ runs:
       shell: bash
       run: |
         # Install notebook/test dependencies
-        echo "Installing: pytest, nbmake ⬇️"
+        echo "Installing: pytest, pytest-cov, nbmake ⬇️"
         # Note: pytest-xdist used for parallel testing
         pip install --disable-pip-version-check -q \
-          pytest nbmake
+          pytest pytest-cov nbmake
 
         echo "Install project and dependencies"
         if [ -f ${{ env.path_prefix }}/pyproject.toml ]; then
@@ -144,11 +149,13 @@ runs:
           if [ "f${{ inputs.permit_fail }}" = 'ftrue' ]; then
             echo "Warning: flag set to permit test failures ⚠️"
             pytest --nbmake \
+              ${{ inputs.pytest_flags }} \
               ${{ env.kernel_flags }} \
               ${{ env.flags }} \
               ${{ env.path_prefix }}/**/*ipynb || true
           else
             pytest --nbmake \
+              ${{ inputs.pytest_flags }} \
               ${{ env.kernel_flags }} \
               ${{ env.flags }} \
               ${{ env.path_prefix }}/**/*ipynb


### PR DESCRIPTION
Added pytest-cov as a dependency, since pyproject.toml can set options which require that it be available. However, percentage threshold for tests can cause the action to fail. This change disables coverage reports by default, sending the option "--no-cov" to pytest.