### PR TITLE
Chore: Default path_prefix to the repository root

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,7 @@ inputs:
     description: 'Directory location containing Python project code'
     # type: string
     required: false
+    default: '.'
   parallel_tests:
     # Note: installs and uses pytest-xdist
     description: 'Parallel pytest/nbmake processes'


### PR DESCRIPTION
## Chore: Default `path_prefix` to the repository root

Every sibling action in this organisation declares `path_prefix` with a `.` default — 28 of them. This one omitted it, so the declared interface didn't state where the action looks by default, and callers had to infer it or read the implementation.

## Behaviour is unchanged

The action **already normalises an empty value to `.`** internally:

```bash
path_prefix="$PATH_PREFIX"
if [ -z "$path_prefix" ]; then
  path_prefix="."
fi
```

So this makes the declared interface match what the implementation always did. The practical gain is that GitHub surfaces the default in the Actions UI and in generated documentation, rather than leaving it blank.

## Context

Part of a small consistency sweep across the estate, alongside [`gradle-build-action#103`](https://github.com/lfreleng-actions/gradle-build-action/pull/103), which aligns that action's outlier `path` input onto `path_prefix`.

Deliberately **not** included in the sweep: `python-audit-action`, which defaults `path_prefix` to `''`. That empty default is load-bearing — it is passed to `pypa/gh-action-pip-audit` as `inputs:`, where empty means *"audit the installed environment"* while `'.'` would mean *"scan this directory"*. Changing it there would alter what gets audited.

## Validation

`pre-commit run --all-files` — all hooks pass.